### PR TITLE
Import DAT file with column date in year fraction format

### DIFF
--- a/TSAnalyzer/models/reader.py
+++ b/TSAnalyzer/models/reader.py
@@ -70,7 +70,12 @@ class Reader(QObject):
             self._readMJD()
             return
         self._parser_dates = {'datetime': index}
-        self._date_parser = lambda x: pd.datetime.strptime(x, formats)
+        if self.time_unit not in col_names:
+            self._date_parser = lambda x: pd.datetime.strptime(x, formats)
+        elif 'years' in col_names:
+            self._date_parser = lambda x: fyear2date(float(x))
+        else:
+          raise Exception('Unsupported time unit')
 
     def _readMJD(self):
         cols = sorted(self.cols.keys())
@@ -155,7 +160,7 @@ class Reader(QObject):
             self.df.insert(0, self.time_unit, dys)
         for col in self.columns:
             if '{}_sigma'.format(col) not in self.df.columns:
-                self.df['{}_sigma'.format(col)] = 1
+                self.df['{}_sigma'.format(col)] = 1.0
         self.is_read = True
 
     def _readNEU(self, filename):


### PR DESCRIPTION
This modification enables import DAT files with format like this

```
# time_unit: years
# unit: mm
# scale: 1000
# column_names: years north east up
# columns_index: 0 1 2 3
# index_cols: years
2007.0027  -0.0520  -0.0719  -0.0091
2007.0055  -0.0510  -0.0705  -0.0064
2007.0082  -0.0513  -0.0698  -0.0084
2007.0110  -0.0497  -0.0703  -0.0022
```