### PR TITLE
Header tool: fix for end lines, new setting - remove old header

### DIFF
--- a/TSAnalyzer/resources/ui/header.ui
+++ b/TSAnalyzer/resources/ui/header.ui
@@ -53,7 +53,7 @@
        <item>
         <widget class="QToolButton" name="addFilesButton">
          <property name="text">
-          <string>...</string>
+          <string>Open</string>
          </property>
          <property name="shortcut">
           <string>Ctrl+O</string>
@@ -352,6 +352,20 @@
           </item>
          </layout>
         </item>
+        <item row="5" column="0">
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+            <widget class="QCheckBox" name="removeOldHeader">
+              <property name="text">
+              <string>Remove old header</string>
+              </property>
+              <property name="checked">
+              <bool>true</bool>
+              </property>
+            </widget>
+          </item>
+         </layout>
+        </item>        
        </layout>
       </widget>
      </item>
@@ -380,7 +394,7 @@
        <item>
         <widget class="QToolButton" name="dirButton">
          <property name="text">
-          <string/>
+          <string>Choose</string>
          </property>
         </widget>
        </item>

--- a/TSAnalyzer/widgets/header_widget.py
+++ b/TSAnalyzer/widgets/header_widget.py
@@ -23,7 +23,8 @@ date_dicts = {'y-m-d': '%Y-%m-%d',
               'minute': '%M',
               'second': '%S',
               'doy': '%j',
-              'mjd': '', }
+              'mjd': '',
+              'years': '' }
 
 
 class TSHeaderThread(QThread):
@@ -53,10 +54,11 @@ class TSHeaderThread(QThread):
             except:
                 return 0
 
-    def render(self, files, directory, header):
+    def render(self, files, directory, header, removeOldHeader=True):
         self.files = files
         self.directory = directory
         self.header = header
+        self.removeOldHeader = removeOldHeader
         self.start()
 
     def run(self):
@@ -64,7 +66,10 @@ class TSHeaderThread(QThread):
         for i, filename in enumerate(self.files):
             with open(filename, 'r') as f:
                 lines = f.readlines()
-                header_line = self.get_header(filename)
+                if self.removeOldHeader:
+                    header_line = self.get_header(filename)
+                else:
+                  header_line = 0
                 content = self.header + ''.join(lines[header_line:])
             new_name = os.path.join(
                 self.directory, os.path.split(filename)[1].split('.')[0] + '.dat')
@@ -190,12 +195,12 @@ class FileHeaderWidget(QWidget):
                 "Please select the target directory.",
                 QMessageBox.Ok)
             return
-        header = ("# time_unit: {}"
-                  "# unit: {}"
-                  "# scale: {}"
-                  "# column_names: {}"
-                  "# columns_index: {}"
-                  "# index_cols: {}"
+        header = ("# time_unit: {}\n"
+                  "# unit: {}\n"
+                  "# scale: {}\n"
+                  "# column_names: {}\n"
+                  "# columns_index: {}\n"
+                  "# index_cols: {}\n"
                   "# index_formats: {}\n").format(
             str(self.timeUnitBox.currentText()),
             str(self.unitEdit.text()),
@@ -208,7 +213,7 @@ class FileHeaderWidget(QWidget):
         files = []
         for index in range(self.filesListWidget.count()):
             files.append(self.filesListWidget.item(index).text())
-        self.thread.render(files, self.directory, header)
+        self.thread.render(files, self.directory, header, self.removeOldHeader.isChecked())
 
     def sigOnWrite(self, progress, filename):
         self.progressBar.setValue(progress)


### PR DESCRIPTION
This request solves:
- fix for header tool to write DAT file header on individual multiple lines
- enables use 'years' column as index time column
- new setting to not remove old header (usable also if original file has no header -> my case) which will skip calling get_header() function

```
2007.0027  -0.0520  -0.0719  -0.0091
2007.0055  -0.0510  -0.0705  -0.0064
2007.0082  -0.0513  -0.0698  -0.0084
2007.0110  -0.0497  -0.0703  -0.0022
2007.0137  -0.0508  -0.0701  -0.0077
2007.0164  -0.0511  -0.0691  -0.0091
2007.0192  -0.0504  -0.0709  -0.0115
2007.0219  -0.0525  -0.0694  -0.0143
2007.0247  -0.0508  -0.0693  -0.0090
``` 